### PR TITLE
its necessary to change Endian.Big to Endian.BIG and Endian.Little to Endian.LITTLE

### DIFF
--- a/src/solaredge_modbus/__init__.py
+++ b/src/solaredge_modbus/__init__.py
@@ -632,7 +632,7 @@ class Battery(SolarEdge):
 
     def __init__(self, offset=False, *args, **kwargs):
         self.model = f"Battery{offset + 1}"
-        self.wordorder = Endian.Little
+        self.wordorder = Endian.LITTLE
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
its necessary to change Endian.Big to Endian.BIG and Endian.Little to Endian.LITTLE, otherwise it will not work with newest pymodbus version